### PR TITLE
Parse /platform/latest into float instead of int

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -179,7 +179,7 @@ func New(
 	}
 
 	if resp.Latest != nil {
-		i, err := strconv.ParseUint(*resp.Latest, 10, 8)
+		i, err := strconv.ParseFloat(*resp.Latest, 64)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Onefs 8.1.x.x changes the return of /platform/latest into a float (eg. 5.1).  Currently, when creating a new client, the response is parsed as an int.  This breaks the instantiation of a new client.   This change moves from doing a parseUint to a parseFloat.  The result is a float64 representative of the latest API version. The float64 is still cast to a unit8 as the original int was before.